### PR TITLE
fix: Correct cron schedule for APM packages update workflow

### DIFF
--- a/.github/workflows/apm-packages-update.yml
+++ b/.github/workflows/apm-packages-update.yml
@@ -24,7 +24,7 @@ on:
         default: true
         type: boolean
   schedule:
-    - cron: '0 0 */3 * *' # every 3 days at midnight UTC
+    - cron: '0 0 * * *' # every 3 days at midnight UTC
 permissions:
   contents: read
 


### PR DESCRIPTION
## What changed
- Corrected the cron expression in `.github/workflows/apm-packages-update.yml`.

## Scope
- This PR description is intentionally limited to the latest change only (cron schedule fix).